### PR TITLE
Date updates for 2025, plus fixed tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2.13  2025-01-02
+    - Update calendar from information in
+      https://www.ox.ac.uk/about/facts-and-figures/dates-of-term
+
 2.12  2020-06-06
     - Update calendar from information in
       https://www.ox.ac.uk/about/facts-and-figures/dates-of-term

--- a/lib/Oxford/Calendar.pm
+++ b/lib/Oxford/Calendar.pm
@@ -5,7 +5,7 @@
 # Dominic Hargreaves (c) 2016
 # Artistic License
 package Oxford::Calendar;
-$Oxford::Calendar::VERSION = "2.12";
+$Oxford::Calendar::VERSION = "2.13";
 use strict;
 use Text::Abbrev;
 use Date::Calc qw(Add_Delta_Days Decode_Date_EU Delta_Days Mktime Easter_Sunday Date_to_Days Day_of_Week_to_Text Day_of_Week);
@@ -634,15 +634,29 @@ Calendar:
     start: 17/01/2021
   Hilary 2022:
     start: 16/01/2022
-    provisional: 1
   Hilary 2023:
     start: 15/01/2023
-    provisional: 1
   Hilary 2024:
     start: 14/01/2024
-    provisional: 1
   Hilary 2025:
     start: 19/01/2025
+  Hilary 2026:
+    start: 18/01/2026
+    provisional: 1
+  Hilary 2027:
+    start: 17/01/2027
+    provisional: 1
+  Hilary 2028:
+    start: 16/01/2028
+    provisional: 1
+  Hilary 2029:
+    start: 14/01/2029
+    provisional: 1
+  Hilary 2030:
+    start: 13/01/2030
+    provisional: 1
+  Hilary 2031:
+    start: 19/01/2031
     provisional: 1
   Michaelmas 2001:
     start: 07/10/2001
@@ -686,15 +700,29 @@ Calendar:
     start: 11/10/2020
   Michaelmas 2021:
     start: 10/10/2021
-    provisional: 1
   Michaelmas 2022:
     start: 09/10/2022
-    provisional: 1
   Michaelmas 2023:
     start: 08/10/2023
-    provisional: 1
   Michaelmas 2024:
     start: 13/10/2024
+  Michaelmas 2025:
+    start: 12/10/2025
+    provisional: 1
+  Michaelmas 2026:
+    start: 11/10/2026
+    provisional: 1
+  Michaelmas 2027:
+    start: 10/10/2027
+    provisional: 1
+  Michaelmas 2028:
+    start: 08/10/2028
+    provisional: 1
+  Michaelmas 2029:
+    start: 07/10/2029
+    provisional: 1
+  Michaelmas 2030:
+    start: 13/10/2030
     provisional: 1
   Trinity 2001:
     start: 22/04/2001
@@ -740,13 +768,27 @@ Calendar:
     start: 25/04/2021
   Trinity 2022:
     start: 24/04/2022
-    provisional: 1
   Trinity 2023:
     start: 23/04/2023
-    provisional: 1
   Trinity 2024:
     start: 21/04/2024
-    provisional: 1
   Trinity 2025:
     start: 27/04/2025
+  Trinity 2026:
+    start: 26/04/2026
+    provisional: 1
+  Trinity 2027:
+    start: 25/04/2027
+    provisional: 1
+  Trinity 2028:
+    start: 23/04/2028
+    provisional: 1
+  Trinity 2029:
+    start: 22/04/2029
+    provisional: 1
+  Trinity 2030:
+    start: 28/04/2030
+    provisional: 1
+  Trinity 2031:
+    start: 27/04/2031
     provisional: 1

--- a/t/00_all.t
+++ b/t/00_all.t
@@ -60,9 +60,9 @@ throws_ok { Oxford::Calendar::ToOx( 1, 11, $future_year, { mode => 'nearest' } )
 throws_ok { Oxford::Calendar::FromOx( $future_year, 'Hilary', 1, 'Sunday' ) } qr/No data for Hilary $future_year/, 'FromOx out of range';
 
 # Provisional
-my $testdate5 = 'Thursday, -2nd week, Hilary 2022';
-is( Oxford::Calendar::ToOx(30, 12, 2021, { mode => 'nearest', confirmed => 0 } ), $testdate5, 'Provisional date' );
-is( Oxford::Calendar::ToOx(30, 12, 2021, { mode => 'nearest', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );
-my $testdate6 = 'Tuesday, 3rd week, Hilary 2022';
-is( Oxford::Calendar::ToOx(1, 2, 2022, { mode => 'full_term', confirmed => 0 } ), $testdate6, 'Provisional date' );
-is( Oxford::Calendar::ToOx(1, 2, 2022, { mode => 'full_term', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );
+my $testdate5 = 'Thursday, -2nd week, Hilary 2031';
+is( Oxford::Calendar::ToOx(26, 12, 2030, { mode => 'nearest', confirmed => 0 } ), $testdate5, 'Provisional date' );
+is( Oxford::Calendar::ToOx(26, 12, 2030, { mode => 'nearest', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );
+my $testdate6 = 'Tuesday, 3rd week, Hilary 2031';
+is( Oxford::Calendar::ToOx(4, 2, 2031, { mode => 'full_term', confirmed => 0 } ), $testdate6, 'Provisional date' );
+is( Oxford::Calendar::ToOx(4, 2, 2031, { mode => 'full_term', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );

--- a/t/00_all.t
+++ b/t/00_all.t
@@ -61,8 +61,8 @@ throws_ok { Oxford::Calendar::FromOx( $future_year, 'Hilary', 1, 'Sunday' ) } qr
 
 # Provisional
 my $testdate5 = 'Thursday, -2nd week, Hilary 2031';
-is( Oxford::Calendar::ToOx(26, 12, 2030, { mode => 'nearest', confirmed => 0 } ), $testdate5, 'Provisional date' );
-is( Oxford::Calendar::ToOx(26, 12, 2030, { mode => 'nearest', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );
+is( Oxford::Calendar::ToOx(2, 1, 2031, { mode => 'nearest', confirmed => 0 } ), $testdate5, 'Provisional date' );
+is( Oxford::Calendar::ToOx(2, 1, 2031, { mode => 'nearest', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );
 my $testdate6 = 'Tuesday, 3rd week, Hilary 2031';
 is( Oxford::Calendar::ToOx(4, 2, 2031, { mode => 'full_term', confirmed => 0 } ), $testdate6, 'Provisional date' );
 is( Oxford::Calendar::ToOx(4, 2, 2031, { mode => 'full_term', confirmed => 1 } ), undef, 'Provisional date with confirmed => 1' );


### PR DESCRIPTION
And add provisional dates through to Trinity 2031.

Now with added passing tests (unlike #1 and #2, now I've remembered how to count to -2 properly)